### PR TITLE
Fix: changed from array_merge to array_replace to avoid reindexing in RM tabs

### DIFF
--- a/resources/views/components/resources/relation-managers/index.blade.php
+++ b/resources/views/components/resources/relation-managers/index.blade.php
@@ -15,7 +15,7 @@
                     $tabs = $managers;
 
                     if ($form) {
-                        $tabs = array_merge([null => null], $tabs);
+                        $tabs = array_replace([null => null], $tabs);
                     }
                 @endphp
 


### PR DESCRIPTION
using array_merge causes the keys to get reindex and if a RM is hidden due to canViewForRecord(), the keys would be wrong and cause an error when selected.